### PR TITLE
fix: remove console logs and integret otel diag logger

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -19,7 +19,7 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "no-console": "off",
+        "no-console": "error",
         "prettier/prettier": "error",
         "require-jsdoc": "off",
         "import/extensions": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-ec2": "^3.27.0",
         "@aws-sdk/client-sts": "^3.51.0",
+        "@opentelemetry/api": "^1.0.4",
         "@opentelemetry/resource-detector-aws": "^1.0.3",
         "@opentelemetry/resource-detector-gcp": "^0.26.2",
         "@opentelemetry/resources": "^1.0.1",
@@ -1978,7 +1979,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
       "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -11402,8 +11402,7 @@
     "@opentelemetry/api": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.0.4.tgz",
-      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
-      "peer": true
+      "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog=="
     },
     "@opentelemetry/core": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
   "dependencies": {
     "@aws-sdk/client-ec2": "^3.27.0",
     "@aws-sdk/client-sts": "^3.51.0",
+    "@opentelemetry/api": "^1.0.4",
     "@opentelemetry/resource-detector-aws": "^1.0.3",
     "@opentelemetry/resource-detector-gcp": "^0.26.2",
     "@opentelemetry/resources": "^1.0.1",

--- a/src/detectors/aws/AwsEc2Detector.ts
+++ b/src/detectors/aws/AwsEc2Detector.ts
@@ -4,6 +4,7 @@ import {
 	ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import { awsEc2Detector as otelAWSEc2Detector } from '@opentelemetry/resource-detector-aws';
+import { cLogger } from '../../utils/logger';
 
 class AwsEc2Detector implements Detector {
 	async detect(_config?: ResourceDetectionConfig): Promise<Resource> {
@@ -17,7 +18,7 @@ class AwsEc2Detector implements Detector {
 			return awsResource;
 		} catch (e) {
 			// TODO: implement PrivateIP detection
-			console.log('Error: ', e);
+			cLogger.error('Error: ', e);
 			return Resource.empty();
 		}
 	}

--- a/src/detectors/aws/AwsEcsDetector.ts
+++ b/src/detectors/aws/AwsEcsDetector.ts
@@ -3,6 +3,7 @@ import {
 	Resource,
 	ResourceDetectionConfig,
 } from '@opentelemetry/resources';
+import { cLogger } from '../../utils/logger';
 
 import { awsEcsDetector as otelAWSEcsDetector } from '@opentelemetry/resource-detector-aws';
 
@@ -13,7 +14,7 @@ class AwsEcsDetector implements Detector {
 
 			return awsResource;
 		} catch (e) {
-			console.log('Error: ', e);
+			cLogger.error('Error: ', e);
 			return Resource.empty();
 		}
 	}

--- a/src/detectors/aws/AwsLambdaDetector.ts
+++ b/src/detectors/aws/AwsLambdaDetector.ts
@@ -9,6 +9,7 @@ import {
 } from '@opentelemetry/semantic-conventions';
 import { awsLambdaDetector as otelAWSLambdaDetector } from '@opentelemetry/resource-detector-aws';
 import { STSClient, GetCallerIdentityCommand } from '@aws-sdk/client-sts';
+import { cLogger } from '../../utils/logger';
 /**
  * The AwsLambdaDetector can be used to detect if a process is running in AWS Lambda
  * and return a {@link Resource} populated with data about the environment.
@@ -26,7 +27,7 @@ export class AwsLambdaDetector implements Detector {
 		try {
 			otelResource = await otelAWSLambdaDetector.detect();
 		} catch (e) {
-			console.log(e);
+			cLogger.error(JSON.stringify(e));
 			return Resource.empty();
 		}
 
@@ -43,7 +44,7 @@ export class AwsLambdaDetector implements Detector {
 
 		if (this.context) {
 			try {
-				console.log('Trying to retrieve invokedFunctionArn from context');
+				cLogger.debug('Trying to retrieve invokedFunctionArn from context');
 				const additionalAttributes = {
 					[SemanticResourceAttributes.FAAS_ID]: (this.context as any)
 						.invokedFunctionArn,
@@ -58,12 +59,12 @@ export class AwsLambdaDetector implements Detector {
 
 				return mergedResource;
 			} catch (e) {
-				console.log('invokedFunctionArn key not found in context', e);
+				cLogger.error('invokedFunctionArn key not found in context', e);
 			}
 		}
 
 		try {
-			console.log(
+			cLogger.debug(
 				'Making Get Caller Identity API call for AWS Lambda Resource Detection',
 			);
 
@@ -82,7 +83,7 @@ export class AwsLambdaDetector implements Detector {
 
 			return mergedResource;
 		} catch (e) {
-			console.log(e);
+			cLogger.debug(JSON.stringify(e));
 			return Resource.empty();
 		}
 	}

--- a/src/detectors/factory.ts
+++ b/src/detectors/factory.ts
@@ -1,4 +1,5 @@
 import { Detector } from '@opentelemetry/resources';
+import { cLogger } from '../utils/logger';
 import {
 	awsEc2Detector,
 	awsEcsDetector,
@@ -54,8 +55,8 @@ class DetectorFactory {
 					}
 					break;
 				default:
-					console.log(
-						'Unknown detector: ',
+					cLogger.debug(
+						'Unknown detector specified in LM_RESOURCE_DETECTOR: ',
 						process.env.LM_RESOURCE_DETECTOR,
 						' using all available detectors',
 					);

--- a/src/detectors/gcp/CloudFunctionDetector.ts
+++ b/src/detectors/gcp/CloudFunctionDetector.ts
@@ -7,6 +7,7 @@ import {
 	CloudProviderValues,
 	SemanticResourceAttributes,
 } from '@opentelemetry/semantic-conventions';
+import { cLogger } from '../../utils/logger';
 const gcpMetadata = require('gcp-metadata');
 
 class CloudFunctionDetector implements Detector {
@@ -34,7 +35,7 @@ class CloudFunctionDetector implements Detector {
 
 			return new Resource(attributes);
 		} catch (e) {
-			console.log('Error: ', e);
+			cLogger.error('Error: ', e);
 			return Resource.empty();
 		}
 	}

--- a/src/detectors/gcp/GcpDetector.ts
+++ b/src/detectors/gcp/GcpDetector.ts
@@ -4,6 +4,7 @@ import {
 	ResourceDetectionConfig,
 } from '@opentelemetry/resources';
 import { gcpDetector as otelGCPDetector } from '@opentelemetry/resource-detector-gcp';
+import { cLogger } from '../../utils/logger';
 
 class GcpDetector implements Detector {
 	async detect(_config?: ResourceDetectionConfig): Promise<Resource> {
@@ -11,7 +12,7 @@ class GcpDetector implements Detector {
 			const gcpResource = await otelGCPDetector.detect();
 			return gcpResource;
 		} catch (e) {
-			console.log('Error: ', e);
+			cLogger.error('Error: ', e);
 			return Resource.empty();
 		}
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {
 	Resource,
 	ResourceDetectionConfig,
 } from '@opentelemetry/resources';
-
+import { cLogger } from './utils/logger';
 import { detectorFactory } from './detectors/factory';
 
 class LMResourceDetector implements Detector {
@@ -14,6 +14,7 @@ class LMResourceDetector implements Detector {
 	}
 
 	async detect(_config?: ResourceDetectionConfig): Promise<Resource> {
+		cLogger.info('detecting resources');
 		const detectors = this.context
 			? detectorFactory.getDetectors(this.context)
 			: detectorFactory.getDetectors();
@@ -24,10 +25,11 @@ class LMResourceDetector implements Detector {
 				Object.keys(resource).length > 0 &&
 				Object.keys(resource.attributes).length > 0
 			) {
+				cLogger.debug('detected resource: ', resource);
 				return resource;
 			}
 		}
-
+		cLogger.info('no resources detected');
 		return Resource.empty();
 	}
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,5 @@
+import { diag } from '@opentelemetry/api';
+
+export const cLogger = diag.createComponentLogger({
+	namespace: '@logicmonitor/lm-telemetry-sdk',
+});


### PR DESCRIPTION
Removed all the console logs and integrated OTel diagnostic logger.
Enabled es lint rule to check for any console logs.
For development purposes, it can be temporary disabled.