### PR TITLE
More test coverage and a breaking change

### DIFF
--- a/src/detectors/aws/AwsLambdaDetector.ts
+++ b/src/detectors/aws/AwsLambdaDetector.ts
@@ -45,6 +45,11 @@ export class AwsLambdaDetector implements Detector {
 		if (this.context) {
 			try {
 				cLogger.debug('Trying to retrieve invokedFunctionArn from context');
+				if (typeof (this.context as any).invokedFunctionArn === 'undefined') {
+					throw new Error(
+						'invokedFunctionArn key not found in context, making API call',
+					);
+				}
 				const additionalAttributes = {
 					[SemanticResourceAttributes.FAAS_ID]: (this.context as any)
 						.invokedFunctionArn,

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,5 +35,4 @@ class LMResourceDetector implements Detector {
 }
 
 export const lmResourceDetector = new LMResourceDetector();
-export const lmResourceDetectorWithContext = LMResourceDetector;
-// export * from './detectors/aws';
+export const LmResourceDetectorWithContext = LMResourceDetector;

--- a/tests/src/detectors/aws/AwsEcsDetector.test.ts
+++ b/tests/src/detectors/aws/AwsEcsDetector.test.ts
@@ -1,13 +1,12 @@
 import { awsEcsDetector } from '../../../../src/detectors/aws/AwsEcsDetector';
-import { mocked } from 'ts-jest/utils';
 import { awsEcsDetector as otelAWSEcsDetector } from '@opentelemetry/resource-detector-aws';
 const { Resource } = require('@opentelemetry/resources');
 // const { SemanticResourceAttributes } =require( "@opentelemetry/semantic-conventions");
 
 jest.mock('@opentelemetry/resource-detector-aws');
 
-beforeEach(() => {
-	mocked(otelAWSEcsDetector.detect).mockClear();
+afterEach(() => {
+	jest.clearAllMocks();
 });
 
 describe('AwsEcsDetector', () => {
@@ -16,26 +15,28 @@ describe('AwsEcsDetector', () => {
 	});
 
 	it('should return empty Resource if ECS not detected', async () => {
-		mocked(otelAWSEcsDetector.detect).mockImplementation((): Promise<any> => {
+		const mockedDetect = jest.spyOn(otelAWSEcsDetector, 'detect');
+		mockedDetect.mockImplementation((): Promise<any> => {
 			return Promise.resolve(Resource.empty());
 		});
 
 		const awsResource = await awsEcsDetector.detect();
 
-		expect(mocked(otelAWSEcsDetector.detect).mock.calls.length).toBe(1);
+		expect(mockedDetect.mock.calls.length).toBe(1);
 		expect(awsResource).toBeDefined();
 		expect(awsResource).toBe(Resource.empty());
 		expect(awsResource.attributes['aws.arn']).toBeUndefined();
 	});
 
 	it('should return empty Resource if there is an exception', async () => {
-		mocked(otelAWSEcsDetector.detect).mockImplementation((): Promise<any> => {
+		const mockedDetect = jest.spyOn(otelAWSEcsDetector, 'detect');
+		mockedDetect.mockImplementation((): Promise<any> => {
 			return Promise.reject(new Error('error'));
 		});
 
 		const awsResource = await awsEcsDetector.detect();
 
-		expect(mocked(otelAWSEcsDetector.detect).mock.calls.length).toBe(1);
+		expect(mockedDetect.mock.calls.length).toBe(1);
 		expect(awsResource).toBeDefined();
 		expect(awsResource).toBe(Resource.empty());
 		expect(awsResource.attributes['aws.arn']).toBeUndefined();

--- a/tests/src/detectors/azure/AzureVMDetector.test.ts
+++ b/tests/src/detectors/azure/AzureVMDetector.test.ts
@@ -81,5 +81,19 @@ describe('AzureVMDetector', () => {
 		expect(resource).toBeDefined();
 		expect(resource).toBe(Resource.empty());
 		scope.done();
+		nock.abortPendingRequests();
+	});
+
+	it('should return empty resource if IDMS returns statusCode not in range [200,300)', async () => {
+		const scope = nock('http://' + azureVMDetector.AZURE_IDMS_ENDPOINT)
+			.get('/metadata/instance')
+			.query({ 'api-version': azureVMDetector.AZURE_API_VERSION })
+			.matchHeader('Metadata', 'true')
+			.reply(500);
+		const resource = await azureVMDetector.detect();
+
+		expect(resource).toBeDefined();
+		expect(resource).toBe(Resource.empty());
+		scope.done();
 	});
 });

--- a/tests/src/detectors/factory.test.ts
+++ b/tests/src/detectors/factory.test.ts
@@ -26,6 +26,13 @@ describe('factory', () => {
 		process.env.LM_RESOURCE_DETECTOR = 'aws_lambda';
 		const detectors = detectorFactory.getDetectors();
 		expect(detectors.length).toBe(1);
+
+		// detector with context
+		const context = {
+			dummyKey: 'dummyValue',
+		};
+		const detectorsWithContext = detectorFactory.getDetectors(context);
+		expect(detectorsWithContext.length).toBe(1);
 	});
 
 	it('should add only GCP detector if gcp_compute_engine specified in ENV', () => {
@@ -56,11 +63,25 @@ describe('factory', () => {
 		process.env.LM_RESOURCE_DETECTOR = 'azure_functions';
 		const detectors = detectorFactory.getDetectors();
 		expect(detectors.length).toBe(1);
+
+		// detector with context
+		const context = {
+			dummyKey: 'dummyValue',
+		};
+		const detectorsWithContext = detectorFactory.getDetectors(context);
+		expect(detectorsWithContext.length).toBe(1);
 	});
 
 	it('should add all detectors if undefined detector specified in ENV', () => {
 		process.env.LM_RESOURCE_DETECTOR = 'undefined';
 		const detectors = detectorFactory.getDetectors();
 		expect(detectors.length).toBe(7);
+
+		// detector with context
+		const context = {
+			dummyKey: 'dummyValue',
+		};
+		const detectorsWithContext = detectorFactory.getDetectors(context);
+		expect(detectorsWithContext.length).toBe(7);
 	});
 });

--- a/tests/src/detectors/gcp/GcpDetectors.test.ts
+++ b/tests/src/detectors/gcp/GcpDetectors.test.ts
@@ -1,5 +1,4 @@
 import { gcpDetector } from '../../../../src/detectors/gcp/GcpDetector';
-import { mocked } from 'ts-jest/utils';
 import { gcpDetector as otelGCPDetector } from '@opentelemetry/resource-detector-gcp';
 import { Resource } from '@opentelemetry/resources';
 const {
@@ -8,13 +7,14 @@ const {
 
 jest.mock('@opentelemetry/resource-detector-gcp');
 
-beforeEach(() => {
-	mocked(otelGCPDetector.detect).mockClear();
+afterEach(() => {
+	jest.clearAllMocks();
 });
 
 describe('GCP Detectors', () => {
 	it('should return empty resource if GCP not detected', async () => {
-		mocked(otelGCPDetector.detect).mockImplementation((): Promise<any> => {
+		const mockedDetect = jest.spyOn(otelGCPDetector, 'detect');
+		mockedDetect.mockImplementation((): Promise<any> => {
 			return Promise.reject(new Error('GCP not detected'));
 		});
 
@@ -30,8 +30,8 @@ describe('GCP Detectors', () => {
 			[SemanticResourceAttributes.HOST_ID]: '1234567890123456789',
 			[SemanticResourceAttributes.CLOUD_PROVIDER]: 'gcp',
 		});
-
-		mocked(otelGCPDetector.detect).mockImplementation((): Promise<any> => {
+		const mockedDetect = jest.spyOn(otelGCPDetector, 'detect');
+		mockedDetect.mockImplementation((): Promise<any> => {
 			return Promise.resolve(expectedResource);
 		});
 

--- a/tests/src/index.test.ts
+++ b/tests/src/index.test.ts
@@ -1,5 +1,55 @@
-describe('is working', () => {
+import {
+	lmResourceDetector,
+	LmResourceDetectorWithContext,
+} from '../../src/index';
+import { detectorFactory } from '../../src/detectors/factory';
+import { Resource } from '@opentelemetry/resources';
+import { DummyDetector } from './testUtils/dummyDetectors';
+describe('testing', () => {
 	it('should work', () => {
 		expect(true).toBeTruthy();
+	});
+});
+
+describe('index.js', () => {
+	it('should be defined', () => {
+		expect(lmResourceDetector).toBeDefined();
+		expect(LmResourceDetectorWithContext).toBeDefined();
+	});
+
+	it('should return empty resource if no resource is detected', async () => {
+		const detectorFactoryMock = jest.spyOn(detectorFactory, 'getDetectors');
+		detectorFactoryMock.mockImplementation(() => {
+			return [new DummyDetector()];
+		});
+		const resource = await lmResourceDetector.detect();
+		expect(resource).toBe(Resource.empty());
+
+		const detectorWithContext = new LmResourceDetectorWithContext({
+			dummyKey: 'dummyValue',
+		});
+		const resource1 = await detectorWithContext.detect();
+		expect(resource1).toBe(Resource.empty());
+		detectorFactoryMock.mockRestore();
+	});
+
+	it('should return resource if detected', async () => {
+		const detectorFactoryMock = jest.spyOn(detectorFactory, 'getDetectors');
+		const expectedResource = new Resource({
+			dummyKey: 'dummyValue',
+		});
+
+		detectorFactoryMock.mockImplementation(() => {
+			return [new DummyDetector(expectedResource)];
+		});
+		const resource = await lmResourceDetector.detect();
+		expect(resource).toBe(expectedResource);
+
+		const detectorWithContext = new LmResourceDetectorWithContext({
+			dummyKey: 'dummyValue',
+		});
+		const resource1 = await detectorWithContext.detect();
+		expect(resource1).toBe(expectedResource);
+		detectorFactoryMock.mockRestore();
 	});
 });

--- a/tests/src/testUtils/dummyDetectors/dummyDetector.ts
+++ b/tests/src/testUtils/dummyDetectors/dummyDetector.ts
@@ -1,0 +1,15 @@
+import {
+	Detector,
+	Resource,
+	ResourceDetectionConfig,
+} from '@opentelemetry/resources';
+
+export class DummyDetector implements Detector {
+	private resource: Resource;
+	constructor(resource: Resource = Resource.empty()) {
+		this.resource = resource;
+	}
+	async detect(_config?: ResourceDetectionConfig): Promise<Resource> {
+		return this.resource;
+	}
+}

--- a/tests/src/testUtils/dummyDetectors/index.ts
+++ b/tests/src/testUtils/dummyDetectors/index.ts
@@ -1,0 +1,1 @@
+export * from './dummyDetector';


### PR DESCRIPTION
add and update test cases
rename `lmResourceDetectorWithContext` to `LmResourceDetectorWithContext` to conform to convention.